### PR TITLE
Neues Vereinsjahr ab 1. Oktober

### DIFF
--- a/statuten/statuten.tex
+++ b/statuten/statuten.tex
@@ -231,7 +231,7 @@
   \li Der Mitgliederbeitrag wird jährlich erhoben.
   \li Die Höhe des Mitgliederbeitrags wird jährlich von der Vereinsversammlung
   festgelegt.
-  \li Das Vereinsjahr beginnt mit dem Frühlings-Semester der HSR.
+  \li Das Vereinsjahr beginnt am 1. Oktober und endet am 30. September.
   \li Der Verein haftet allein mit dem Vereinsvermögen.
 \lo
 


### PR DESCRIPTION
Gemäss  Protokoll Vorstandssitzung 2016-07 #15 soll das Vereinsjahr neu auf den 1. Oktober verschoben werden.

Dieser Pull Request muss an der nächsten GV beschlossen werden.
