### PR TITLE
Fix formatting in GV 2020 protocol

### DIFF
--- a/protokolle/2020/Generalversammlung_20_21.md
+++ b/protokolle/2020/Generalversammlung_20_21.md
@@ -66,7 +66,6 @@ Jahresabschluss für das Vereinsjahr 2019/20 wurde einstimmig angenommen
 
 Vermögen: 1'718.85 CHF
 
-|--------------------|----------------|
 | Budgetpunkt        | Budget 2020/21 |
 |--------------------|----------------|
 | **Einnahmen**      |                |
@@ -80,7 +79,6 @@ Vermögen: 1'718.85 CHF
 | Generalversammlung | CHF -   400.00 |
 | Studentenportal    | CHF - 2'500.00 |
 | Vorstandsanlass    | CHF - 1'200.00 |
-|--------------------|----------------|
 |                    |                |
 | **Summe**          |   CHF    84.20 |
 

--- a/protokolle/2020/Generalversammlung_20_21.md
+++ b/protokolle/2020/Generalversammlung_20_21.md
@@ -71,7 +71,7 @@ Vermögen: 1'718.85 CHF
 | **Einnahmen**      |                |
 | Mitgliederbeiträge | CHF       0.00 |
 | Sponsoring         | CHF   6'000.00 |
-| ** Ausgaben**      |                |
+| **Ausgaben**       |                |
 | Bankspesen         | CHF -     5.10 |
 | Domains            | CHF -    10.70 |
 | Marketing / Flyer  | CHF -   300.00 |

--- a/protokolle/2020/Generalversammlung_20_21.md
+++ b/protokolle/2020/Generalversammlung_20_21.md
@@ -8,8 +8,8 @@ Total Stimmenzahl: 16 Stimmen
 
 ## Ort und Zeit
 
-**Ort:** Online(Microsoft Teams)
-**Tag:** 19.10.2020
+**Ort:** Online(Microsoft Teams)\
+**Tag:** 19.10.2020\
 **Zeit:** 17:00 Uhr bis 19.00 Uhr
 
 ## Traktanden

--- a/protokolle/2020/Generalversammlung_20_21.md
+++ b/protokolle/2020/Generalversammlung_20_21.md
@@ -187,7 +187,7 @@ Weitere Schritte des Vereinen bezüglich dem Studentenportal
 - Beistand wird offen gelassen und die Aufgaben übernimmt der Vorstand bis zur nächsten ausserordentlichen GV die in einem halben Jahr statt finden soll
 - Neuer Beistand soll in einer baldigen ausserordentlichen GV in der Vorstand aufgenommen werden
 
-### 9– Abschluss der GV
+### 9 – Abschluss der GV
 
 Abschluss der GV durch Präsidenten Fabian Germann.
 

--- a/protokolle/2020/Generalversammlung_20_21.md
+++ b/protokolle/2020/Generalversammlung_20_21.md
@@ -8,7 +8,7 @@ Total Stimmenzahl: 16 Stimmen
 
 ## Ort und Zeit
 
-**Ort:** Online(Microsoft Teams)\
+**Ort:** Online (Microsoft Teams)\
 **Tag:** 19.10.2020\
 **Zeit:** 17:00 Uhr bis 19.00 Uhr
 


### PR DESCRIPTION
- add line breaks in [section "Ort und Zeit"](https://github.com/openhsr/verein/blob/master/protokolle/2020/Generalversammlung_20_21.md#ort-und-zeit)
- add space before "("
- fix table markup to be rendered correctly on GitHub
- fix bold markup in budget table
- uniform spacing around the "–"s in section titles