### PR TITLE
GV 2020/21: Jahresabschluss hat Bilanz, nicht Budget

### DIFF
--- a/protokolle/2020/Generalversammlung_20_21.md
+++ b/protokolle/2020/Generalversammlung_20_21.md
@@ -34,7 +34,7 @@ GV-Protokoll vom 29.10.19 wird mit 13 von 14 Ja Stimmen angenommen.
 
 **Einnahmen und Ausgaben**
 
-| Budgetpunkt        | Budget         |
+| Budgetpunkt        | Bilanz         |
 | ------------------ | -------------- |
 | **Einnahmen**      |                |
 | Mitgliederbeiträge | CHF       0.00 |


### PR DESCRIPTION
Auch die Zahlen sind anders als in https://github.com/openhsr/verein/blob/master/protokolle/2019/10_generalversammlung/protokoll.md#budget-vereinsjahr-1920, also wird es sich wohl tatsächlich um die Bilanz, nicht um das Budget handeln.